### PR TITLE
Git ignore .sass-cache, updated Gemfile.lock, fixed sass warning

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
-.sass_cache/*
+.sass-cache/*
 .DS_Store

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,7 +6,6 @@ GEM
     rack (1.4.1)
     rack-protection (1.2.0)
       rack
-    redcarpet (2.1.1)
     sinatra (1.3.2)
       rack (~> 1.3, >= 1.3.6)
       rack-protection (~> 1.2)
@@ -21,6 +20,5 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  redcarpet
   sinatra
   thin

--- a/server.rb
+++ b/server.rb
@@ -1,5 +1,6 @@
 require 'sinatra'
 require 'yaml'
+require 'sass'
 
 def file_relative(path)
   file = File.join(File.dirname(__FILE__), path)


### PR DESCRIPTION
Regarding sass warning, when I started server I got this:

```
WARN: tilt autoloading 'sass' in a non thread-safe way; explicit require 'sass' suggested.
```
